### PR TITLE
Avoid using a static value to seed rng

### DIFF
--- a/1_capture.flow.yaml
+++ b/1_capture.flow.yaml
@@ -2,11 +2,15 @@ captures:
   examples/segment/event-generator:
     endpoint:
       airbyteSource:
-        image: ghcr.io/estuary/demos-segmentation/event-generator:107ebda
+        image: ghcr.io/estuary/demos-segmentation/event-generator:9f980f9
         config:
           maxEventsPerSecond: 1000
           # Maximum number of Events produced per second
-          # [integer] (required)
+          # [integer]
+
+          seed: 8675309
+          # Random Number Generator Seed Value
+          # [integer]
 
           segmentCardinality: 500
           # Number of unique segments to use when generating events

--- a/event-generator/events.go
+++ b/event-generator/events.go
@@ -79,9 +79,7 @@ type eventSource struct {
 	tickCh *time.Ticker
 }
 
-func newEventSource(segmentCardinality uint64, userCardinality uint64) eventSource {
-	var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
-
+func newEventSource(rnd *rand.Rand, segmentCardinality uint64, userCardinality uint64) eventSource {
 	return eventSource{
 		rnd:             rnd,
 		rndSegment:      rand.NewZipf(rnd, segmentSkew, 1, segmentCardinality),

--- a/event-generator/events.go
+++ b/event-generator/events.go
@@ -80,7 +80,7 @@ type eventSource struct {
 }
 
 func newEventSource(segmentCardinality uint64, userCardinality uint64) eventSource {
-	var rnd = rand.New(rand.NewSource(8675309))
+	var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	return eventSource{
 		rnd:             rnd,


### PR DESCRIPTION
This probably makes little difference within the context of this
particular demo but this will cause duplicate uuids to be generated
between invocations.

I noticed this while I was working on the Rockset demo, as subsequent
invocations of the generator (restarting `flowctl develop`) would add
events to a collection which had the same uuid key.

This was rather unexpected...